### PR TITLE
Fix typo in login function name

### DIFF
--- a/app/src/main/java/com/icl/surveillance/network/RetrofitCallsAuthentication.kt
+++ b/app/src/main/java/com/icl/surveillance/network/RetrofitCallsAuthentication.kt
@@ -29,11 +29,11 @@ class RetrofitCallsAuthentication {
 
         CoroutineScope(Dispatchers.Main).launch {
             val job = Job()
-            CoroutineScope(Dispatchers.IO + job).launch { starLogin(context, dbSignIn) }.join()
+            CoroutineScope(Dispatchers.IO + job).launch { startLogin(context, dbSignIn) }.join()
         }
     }
 
-    private fun starLogin(context: Context, dbSignIn: DbSignIn) {
+    private fun startLogin(context: Context, dbSignIn: DbSignIn) {
 
         val job1 = Job()
         CoroutineScope(Dispatchers.Main + job1).launch {


### PR DESCRIPTION
## Summary
- rename `starLogin` function to `startLogin`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b61edaf5e0832998cfce539767c11f