### PR TITLE
Rename date formatter method and update call sites

### DIFF
--- a/app/src/main/java/com/icl/surveillance/utils/FormatterClass.kt
+++ b/app/src/main/java/com/icl/surveillance/utils/FormatterClass.kt
@@ -44,7 +44,11 @@ class FormatterClass {
         editor.apply()
     }
 
-    fun formatCurrentDateTime(date: Date): String {
+    /**
+     * Formats the provided [date] into a string using the pattern
+     * `yyyy-MM-dd HH:mm:ss` and the English locale.
+     */
+    fun formatDateTime(date: Date): String {
         return dateInverseFormatSeconds.format(date)
     }
 

--- a/app/src/main/java/com/icl/surveillance/viewmodels/AddClientViewModel.kt
+++ b/app/src/main/java/com/icl/surveillance/viewmodels/AddClientViewModel.kt
@@ -142,9 +142,9 @@ class AddClientViewModel(application: Application, private val state: SavedState
             coding0.display = "System Creation"
             codingList0.add(coding0)
             typeCodeableConcept0.coding = codingList0
-            typeCodeableConcept0.text = FormatterClass().formatCurrentDateTime(Date())
+            typeCodeableConcept0.text = FormatterClass().formatDateTime(Date())
 
-            identifierSystem0.value = FormatterClass().formatCurrentDateTime(Date())
+            identifierSystem0.value = FormatterClass().formatDateTime(Date())
             identifierSystem0.system = "system-creation"
             identifierSystem0.type = typeCodeableConcept0
 

--- a/app/src/main/java/com/icl/surveillance/viewmodels/ScreenerViewModel.kt
+++ b/app/src/main/java/com/icl/surveillance/viewmodels/ScreenerViewModel.kt
@@ -93,9 +93,9 @@ class ScreenerViewModel(application: Application, private val state: SavedStateH
                     coding0.display = "System Creation"
                     codingList0.add(coding0)
                     typeCodeableConcept0.coding = codingList0
-                    typeCodeableConcept0.text = FormatterClass().formatCurrentDateTime(Date())
+                    typeCodeableConcept0.text = FormatterClass().formatDateTime(Date())
 
-                    identifierSystem0.value = FormatterClass().formatCurrentDateTime(Date())
+                    identifierSystem0.value = FormatterClass().formatDateTime(Date())
                     identifierSystem0.system = "system-creation"
                     identifierSystem0.type = typeCodeableConcept0
 
@@ -242,9 +242,9 @@ class ScreenerViewModel(application: Application, private val state: SavedStateH
                     coding0.display = "System Creation"
                     codingList0.add(coding0)
                     typeCodeableConcept0.coding = codingList0
-                    typeCodeableConcept0.text = FormatterClass().formatCurrentDateTime(Date())
+                    typeCodeableConcept0.text = FormatterClass().formatDateTime(Date())
 
-                    identifierSystem0.value = FormatterClass().formatCurrentDateTime(Date())
+                    identifierSystem0.value = FormatterClass().formatDateTime(Date())
                     identifierSystem0.system = "system-creation"
                     identifierSystem0.type = typeCodeableConcept0
 


### PR DESCRIPTION
## Summary
- rename `formatCurrentDateTime` to `formatDateTime`
- update ScreenerViewModel and AddClientViewModel to use new method
- document date formatter method

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6202a379c8329afd93eb116e50d5b