### PR TITLE
Add launch context demo questionnaire

### DIFF
--- a/app/src/main/assets/launch-context-demo.json
+++ b/app/src/main/assets/launch-context-demo.json
@@ -1,0 +1,90 @@
+{
+  "resourceType": "Questionnaire",
+  "meta": {
+    "profile": [
+      "http://hl7.org/fhir/4.0/StructureDefinition/Questionnaire"
+    ]
+  },
+  "status": "active",
+  "title": "Launch Context Demo",
+  "description": "Demonstrates resolving launch context variables supplied by the host app.",
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-launchContext",
+      "extension": [
+        {
+          "url": "name",
+          "valueCoding": {
+            "system": "http://hl7.org/fhir/uv/sdc/CodeSystem/launchContext",
+            "code": "client",
+            "display": "Client as a QuestionnaireResponse"
+          }
+        },
+        {
+          "url": "type",
+          "valueCode": "QuestionnaireResponse"
+        }
+      ]
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "facilityReference",
+        "language": "text/fhirpath",
+        "expression": "%launchContext['client'].item.where(linkId='819946803677').answer.value"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "facilityDisplay",
+        "language": "text/fhirpath",
+        "expression": "%launchContext['client'].item.where(linkId='819946803677').answer.value.display"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "countyDisplay",
+        "language": "text/fhirpath",
+        "expression": "%launchContext['client'].item.where(linkId='294367770999').answer.value.display"
+      }
+    }
+  ],
+  "item": [
+    {
+      "linkId": "context-summary",
+      "text": "Launch Context Summary",
+      "type": "display",
+      "_text": {
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/StructureDefinition/cqf-expression",
+            "valueExpression": {
+              "language": "text/fhirpath",
+              "expression": "'County: ' & coalesce(%countyDisplay, 'Unknown') & '\\nFacility: ' & coalesce(%facilityDisplay, 'Unknown')"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "linkId": "facility-name",
+      "text": "Facility (from launch context)",
+      "type": "string",
+      "initialExpression": {
+        "language": "text/fhirpath",
+        "expression": "coalesce(%facilityDisplay, '')"
+      }
+    },
+    {
+      "linkId": "facility-reference",
+      "text": "Facility Reference",
+      "type": "reference",
+      "initialExpression": {
+        "language": "text/fhirpath",
+        "expression": "%facilityReference"
+      }
+    }
+  ]
+}

--- a/app/src/main/java/com/icl/surveillance/clients/AddClientFragment.kt
+++ b/app/src/main/java/com/icl/surveillance/clients/AddClientFragment.kt
@@ -14,6 +14,8 @@ import ca.uhn.fhir.context.FhirContext
 import com.google.android.fhir.datacapture.QuestionnaireFragment
 import com.icl.surveillance.R
 import com.icl.surveillance.utils.ProgressDialogManager
+import com.icl.surveillance.utils.QuestionnaireLaunchContextFactory
+import com.icl.surveillance.utils.QuestionnaireLaunchContextKeys.QUESTIONNAIRE_LAUNCH_CONTEXTS_KEY
 import com.icl.surveillance.viewmodels.AddClientViewModel
 import kotlinx.coroutines.launch
 import org.hl7.fhir.r4.model.QuestionnaireResponse
@@ -67,17 +69,31 @@ class AddClientFragment : Fragment(R.layout.fragment_add_client) {
 
     private fun updateArguments() {
         requireArguments().putString(QUESTIONNAIRE_FILE_PATH_KEY, "add-case.json")
+        if (!requireArguments().containsKey(QUESTIONNAIRE_LAUNCH_CONTEXTS_KEY)) {
+            val launchContexts =
+                QuestionnaireLaunchContextFactory.defaultLocationLaunchContexts(requireContext())
+            if (launchContexts.isNotEmpty()) {
+                requireArguments().putSerializable(
+                    QUESTIONNAIRE_LAUNCH_CONTEXTS_KEY,
+                    ArrayList(launchContexts)
+                )
+            }
+        }
     }
 
     private fun addQuestionnaireFragment() {
         childFragmentManager.commit {
             add(
                 R.id.add_patient_container,
-                QuestionnaireFragment.builder()
-                    .setQuestionnaire(viewModel.questionnaireJson)
-                    .setShowCancelButton(true)
-                    .setSubmitButtonText("Submit")
-                    .build(),
+                QuestionnaireFragment.builder().apply {
+                    setQuestionnaire(viewModel.questionnaireJson)
+                    setShowCancelButton(true)
+                    setSubmitButtonText("Submit")
+                    val launchContexts = viewModel.questionnaireLaunchContexts
+                    if (launchContexts.isNotEmpty()) {
+                        setQuestionnaireLaunchContext(launchContexts)
+                    }
+                }.build(),
                 QUESTIONNAIRE_FRAGMENT_TAG,
             )
         }

--- a/app/src/main/java/com/icl/surveillance/clients/AddParentCaseActivity.kt
+++ b/app/src/main/java/com/icl/surveillance/clients/AddParentCaseActivity.kt
@@ -31,6 +31,8 @@ import com.icl.surveillance.utils.ContribQuestionnaireItemViewHolderFactoryMatch
 import com.icl.surveillance.utils.FormatterClass
 import com.icl.surveillance.utils.LocationUtils
 import com.icl.surveillance.utils.ProgressDialogManager
+import com.icl.surveillance.utils.QuestionnaireLaunchContextFactory
+import com.icl.surveillance.utils.QuestionnaireLaunchContextKeys.QUESTIONNAIRE_LAUNCH_CONTEXTS_KEY
 import com.icl.surveillance.viewmodels.AddClientViewModel
 import kotlinx.coroutines.launch
 import org.hl7.fhir.r4.model.Questionnaire
@@ -254,6 +256,10 @@ class AddParentCaseActivity : AppCompatActivity() {
                                     .LOCATION_WIDGET_PROVIDER,
                             )
                             setQuestionnaire(viewModel.questionnaireJson)
+                            val launchContexts = viewModel.questionnaireLaunchContexts
+                            if (launchContexts.isNotEmpty()) {
+                                setQuestionnaireLaunchContext(launchContexts)
+                            }
                         }
 //                    LayoutListViewModel.questionnaireLambdaMap[args.questionnaireLambdaKey ?: ""]!!.invoke(
 //                        questionnaireFragmentBuilder,
@@ -319,6 +325,15 @@ class AddParentCaseActivity : AppCompatActivity() {
     private fun updateArguments() {
         val json = FormatterClass().getSharedPref("questionnaire", this@AddParentCaseActivity)
         intent.putExtra(QUESTIONNAIRE_FILE_PATH_KEY, json)
+        if (!intent.hasExtra(QUESTIONNAIRE_LAUNCH_CONTEXTS_KEY)) {
+            val launchContexts = QuestionnaireLaunchContextFactory.defaultLocationLaunchContexts(this)
+            if (launchContexts.isNotEmpty()) {
+                intent.putExtra(
+                    QUESTIONNAIRE_LAUNCH_CONTEXTS_KEY,
+                    ArrayList(launchContexts)
+                )
+            }
+        }
     }
 
     override fun onSupportNavigateUp(): Boolean {

--- a/app/src/main/java/com/icl/surveillance/ui/patients/AddCaseActivity.kt
+++ b/app/src/main/java/com/icl/surveillance/ui/patients/AddCaseActivity.kt
@@ -23,6 +23,8 @@ import com.icl.surveillance.utils.ContribQuestionnaireItemViewHolderFactoryMatch
 import com.icl.surveillance.utils.FormatterClass
 import com.icl.surveillance.utils.LocationUtils
 import com.icl.surveillance.utils.ProgressDialogManager
+import com.icl.surveillance.utils.QuestionnaireLaunchContextFactory
+import com.icl.surveillance.utils.QuestionnaireLaunchContextKeys.QUESTIONNAIRE_LAUNCH_CONTEXTS_KEY
 import com.icl.surveillance.viewmodels.ScreenerViewModel
 import kotlinx.coroutines.launch
 import org.hl7.fhir.r4.model.QuestionnaireResponse
@@ -207,6 +209,10 @@ class AddCaseActivity : AppCompatActivity() {
                                     .LOCATION_WIDGET_PROVIDER,
                             )
                             setQuestionnaire(viewModel.questionnaire)
+                            val launchContexts = viewModel.questionnaireLaunchContexts
+                            if (launchContexts.isNotEmpty()) {
+                                setQuestionnaireLaunchContext(launchContexts)
+                            }
                         }
                     add(
                         R.id.add_patient_container,
@@ -258,6 +264,15 @@ class AddCaseActivity : AppCompatActivity() {
     private fun updateArguments() {
         val json = FormatterClass().getSharedPref("questionnaire", this@AddCaseActivity)
         intent.putExtra(QUESTIONNAIRE_FILE_PATH_KEY, json)
+        if (!intent.hasExtra(QUESTIONNAIRE_LAUNCH_CONTEXTS_KEY)) {
+            val launchContexts = QuestionnaireLaunchContextFactory.defaultLocationLaunchContexts(this)
+            if (launchContexts.isNotEmpty()) {
+                intent.putExtra(
+                    QUESTIONNAIRE_LAUNCH_CONTEXTS_KEY,
+                    ArrayList(launchContexts)
+                )
+            }
+        }
     }
 
     override fun onBackPressed() {

--- a/app/src/main/java/com/icl/surveillance/ui/patients/responses/EditChecklistActivity.kt
+++ b/app/src/main/java/com/icl/surveillance/ui/patients/responses/EditChecklistActivity.kt
@@ -21,6 +21,10 @@ import com.icl.surveillance.databinding.ActivityEditChecklistBinding
 import com.icl.surveillance.utils.ContribQuestionnaireItemViewHolderFactoryMatchersProviderFactory
 import com.icl.surveillance.utils.FormatterClass
 import com.icl.surveillance.utils.ProgressDialogManager
+import com.icl.surveillance.utils.QuestionnaireLaunchContextEntry
+import com.icl.surveillance.utils.QuestionnaireLaunchContextEntry.Companion.toLaunchContexts
+import com.icl.surveillance.utils.QuestionnaireLaunchContextFactory
+import com.icl.surveillance.utils.QuestionnaireLaunchContextKeys.QUESTIONNAIRE_LAUNCH_CONTEXTS_KEY
 import com.icl.surveillance.viewmodels.EditSupervisorChecklistViewModel
 import com.icl.surveillance.viewmodels.factories.EditSupervisorChecklistViewModelFactory
 import kotlinx.coroutines.launch
@@ -119,6 +123,12 @@ class EditChecklistActivity : AppCompatActivity() {
 
         lifecycleScope.launch {
             supportFragmentManager.commit {
+                val launchContexts =
+                    toLaunchContexts(
+                        QuestionnaireLaunchContextFactory.defaultLocationLaunchContexts(
+                            this@EditChecklistActivity
+                        )
+                    )
                 add(
                     R.id.add_patient_container,
                     QuestionnaireFragment.builder().apply {
@@ -126,6 +136,9 @@ class EditChecklistActivity : AppCompatActivity() {
                             ContribQuestionnaireItemViewHolderFactoryMatchersProviderFactory
                                 .LOCATION_WIDGET_PROVIDER,
                         )
+                        if (launchContexts.isNotEmpty()) {
+                            setQuestionnaireLaunchContext(launchContexts)
+                        }
                     }
                         .setQuestionnaire(pair.first)
                         .setQuestionnaireResponse(pair.second)
@@ -178,6 +191,15 @@ class EditChecklistActivity : AppCompatActivity() {
     private fun updateArguments() {
         val json = FormatterClass().getSharedPref("questionnaire", this)
         intent.putExtra(QUESTIONNAIRE_FILE_PATH_KEY, json)
+        if (!intent.hasExtra(QUESTIONNAIRE_LAUNCH_CONTEXTS_KEY)) {
+            val launchContexts = QuestionnaireLaunchContextFactory.defaultLocationLaunchContexts(this)
+            if (launchContexts.isNotEmpty()) {
+                intent.putExtra(
+                    QUESTIONNAIRE_LAUNCH_CONTEXTS_KEY,
+                    ArrayList(launchContexts)
+                )
+            }
+        }
     }
 
     companion object {

--- a/app/src/main/java/com/icl/surveillance/utils/QuestionnaireLaunchContextConfig.kt
+++ b/app/src/main/java/com/icl/surveillance/utils/QuestionnaireLaunchContextConfig.kt
@@ -1,0 +1,134 @@
+package com.icl.surveillance.utils
+
+import android.content.Context
+import ca.uhn.fhir.context.FhirContext
+import ca.uhn.fhir.context.FhirVersionEnum
+import com.google.android.fhir.datacapture.QuestionnaireFragment
+import java.io.Serializable
+import org.hl7.fhir.r4.model.Coding
+import org.hl7.fhir.r4.model.QuestionnaireResponse
+import org.hl7.fhir.r4.model.Reference
+import org.hl7.fhir.r4.model.Resource
+
+object QuestionnaireLaunchContextKeys {
+    const val QUESTIONNAIRE_LAUNCH_CONTEXTS_KEY = "questionnaire-launch-contexts"
+}
+
+data class CodingEntry(
+    val system: String?,
+    val code: String?,
+    val display: String?
+) : Serializable {
+    fun toCoding(): Coding =
+        Coding().apply {
+            system = this@CodingEntry.system
+            code = this@CodingEntry.code
+            display = this@CodingEntry.display
+        }
+
+    companion object {
+        fun fromCoding(coding: Coding): CodingEntry =
+            CodingEntry(coding.system, coding.code, coding.display)
+    }
+}
+
+data class QuestionnaireLaunchContextEntry(
+    val nameCoding: CodingEntry?,
+    val resourceJson: String
+) : Serializable {
+    fun toLaunchContext(): QuestionnaireFragment.QuestionnaireLaunchContext {
+        val resource = JSON_PARSER.parseResource(resourceJson) as Resource
+        return QuestionnaireFragment.QuestionnaireLaunchContext(
+            nameCoding?.toCoding(),
+            resource
+        )
+    }
+
+    companion object {
+        private val FHIR_CONTEXT: FhirContext = FhirContext.forCached(FhirVersionEnum.R4)
+        private val JSON_PARSER = FHIR_CONTEXT.newJsonParser()
+
+        fun fromResource(
+            nameCoding: Coding?,
+            resource: Resource
+        ): QuestionnaireLaunchContextEntry =
+            QuestionnaireLaunchContextEntry(
+                nameCoding?.let { CodingEntry.fromCoding(it) },
+                JSON_PARSER.encodeResourceToString(resource)
+            )
+
+        fun toLaunchContexts(
+            entries: List<QuestionnaireLaunchContextEntry>
+        ): List<QuestionnaireFragment.QuestionnaireLaunchContext> =
+            entries.map { it.toLaunchContext() }
+    }
+}
+
+object QuestionnaireLaunchContextFactory {
+    private val CONTEXT_CODING = Coding().apply {
+        system = "http://hl7.org/fhir/uv/sdc/CodeSystem/launchContext"
+        code = "client"
+        display = "Client as a QuestionnaireResponse"
+    }
+
+    fun defaultLocationLaunchContexts(
+        context: Context
+    ): List<QuestionnaireLaunchContextEntry> {
+        val formatter = FormatterClass()
+        val countyReference = formatter.getSharedPref("county", context)
+        val countyName = formatter.getSharedPref("countyName", context)
+        val subCountyReference = formatter.getSharedPref("subCounty", context)
+        val subCountyName = formatter.getSharedPref("subCountyName", context)
+        val wardReference = formatter.getSharedPref("ward", context)
+        val wardName = formatter.getSharedPref("wardName", context)
+        val facilityReference = formatter.getSharedPref("facility", context)
+        val facilityName = formatter.getSharedPref("facilityName", context)
+
+        val hasReference = listOf(
+            countyReference,
+            subCountyReference,
+            wardReference,
+            facilityReference
+        ).any { !it.isNullOrBlank() }
+        if (!hasReference) {
+            return emptyList()
+        }
+
+        val response = QuestionnaireResponse().apply {
+            status = QuestionnaireResponse.QuestionnaireResponseStatus.COMPLETED
+            listOf(
+                LaunchItem("294367770999", countyReference, countyName),
+                LaunchItem("438862163919", countyReference, countyName),
+                LaunchItem("a4-county", countyReference, countyName),
+                LaunchItem("819946803642", subCountyReference, subCountyName),
+                LaunchItem("a3-sub-county", subCountyReference, subCountyName),
+                LaunchItem("819943434", wardReference, wardName),
+                LaunchItem("819946803677", facilityReference, facilityName)
+            ).forEach { item ->
+                item.reference?.takeIf { it.isNotBlank() }?.let { referenceValue ->
+                    addItem().apply {
+                        linkId = item.linkId
+                        addAnswer().apply {
+                            value = Reference(referenceValue).apply {
+                                item.display?.takeIf { it.isNotBlank() }?.let { display = it }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        return listOf(
+            QuestionnaireLaunchContextEntry.fromResource(
+                CONTEXT_CODING,
+                response
+            )
+        )
+    }
+
+    private data class LaunchItem(
+        val linkId: String,
+        val reference: String?,
+        val display: String?
+    )
+}

--- a/app/src/main/java/com/icl/surveillance/viewmodels/AddClientViewModel.kt
+++ b/app/src/main/java/com/icl/surveillance/viewmodels/AddClientViewModel.kt
@@ -10,6 +10,7 @@ import androidx.lifecycle.viewModelScope
 import ca.uhn.fhir.context.FhirContext
 import ca.uhn.fhir.context.FhirVersionEnum
 import com.google.android.fhir.FhirEngine
+import com.google.android.fhir.datacapture.QuestionnaireFragment
 import com.google.android.fhir.datacapture.validation.Invalid
 import com.google.android.fhir.datacapture.validation.QuestionnaireResponseValidator
 import com.ibm.icu.text.SimpleDateFormat
@@ -22,6 +23,9 @@ import com.icl.surveillance.utils.Constants.ALL_MPOX_LINK_IDS
 import com.icl.surveillance.utils.Constants.WEEK_ENDING_DATE
 import com.icl.surveillance.utils.FormatterClass
 import com.icl.surveillance.utils.QuestionnaireHelper
+import com.icl.surveillance.utils.QuestionnaireLaunchContextEntry
+import com.icl.surveillance.utils.QuestionnaireLaunchContextEntry.Companion.toLaunchContexts
+import com.icl.surveillance.utils.QuestionnaireLaunchContextKeys.QUESTIONNAIRE_LAUNCH_CONTEXTS_KEY
 import java.time.LocalDate
 import java.util.Date
 import java.util.UUID
@@ -60,6 +64,10 @@ class AddClientViewModel(application: Application, private val state: SavedState
         get() = fetchQuestionnaireJson()
 
     val isPatientSaved = MutableLiveData<Boolean>()
+
+    val questionnaireLaunchContexts: List<QuestionnaireFragment.QuestionnaireLaunchContext>
+        get() = state.get<ArrayList<QuestionnaireLaunchContextEntry>>(QUESTIONNAIRE_LAUNCH_CONTEXTS_KEY)
+            ?.let { toLaunchContexts(it) } ?: emptyList()
 
     private val questionnaire: Questionnaire
         get() = FhirContext.forCached(FhirVersionEnum.R4).newJsonParser()

--- a/app/src/main/java/com/icl/surveillance/viewmodels/ScreenerViewModel.kt
+++ b/app/src/main/java/com/icl/surveillance/viewmodels/ScreenerViewModel.kt
@@ -10,12 +10,16 @@ import androidx.lifecycle.viewModelScope
 import ca.uhn.fhir.context.FhirContext
 import ca.uhn.fhir.context.FhirVersionEnum
 import com.google.android.fhir.FhirEngine
+import com.google.android.fhir.datacapture.QuestionnaireFragment
 import com.google.android.fhir.datacapture.mapping.ResourceMapper
 import com.icl.surveillance.clients.AddClientFragment.Companion.QUESTIONNAIRE_FILE_PATH_KEY
 import com.icl.surveillance.fhir.FhirApplication
 import com.icl.surveillance.models.QuestionnaireAnswer
 import com.icl.surveillance.utils.FormatterClass
 import com.icl.surveillance.utils.QuestionnaireHelper
+import com.icl.surveillance.utils.QuestionnaireLaunchContextEntry
+import com.icl.surveillance.utils.QuestionnaireLaunchContextEntry.Companion.toLaunchContexts
+import com.icl.surveillance.utils.QuestionnaireLaunchContextKeys.QUESTIONNAIRE_LAUNCH_CONTEXTS_KEY
 import java.util.Date
 import java.util.UUID
 import kotlinx.coroutines.CoroutineScope
@@ -42,6 +46,10 @@ class ScreenerViewModel(application: Application, private val state: SavedStateH
         get() = getQuestionnaireJson()
 
     val isResourcesSaved = MutableLiveData<Boolean>()
+
+    val questionnaireLaunchContexts: List<QuestionnaireFragment.QuestionnaireLaunchContext>
+        get() = state.get<ArrayList<QuestionnaireLaunchContextEntry>>(QUESTIONNAIRE_LAUNCH_CONTEXTS_KEY)
+            ?.let { toLaunchContexts(it) } ?: emptyList()
 
     private val questionnaireResource: Questionnaire
         get() =


### PR DESCRIPTION
## Summary
- add a minimal questionnaire asset that declares the launch context dependency
- demonstrate using launch context variables to populate display text and initial answers

## Testing
- not run (Android SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_b_690aedf0e4948321a8258b0b51ab6568