### PR TITLE
Move heavy viewmodel work off the main thread

### DIFF
--- a/app/src/main/java/com/icl/surveillance/auth/ForgotPasswordActivity.kt
+++ b/app/src/main/java/com/icl/surveillance/auth/ForgotPasswordActivity.kt
@@ -9,15 +9,15 @@ import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
+import androidx.lifecycle.lifecycleScope
 import com.icl.surveillance.R
 import com.icl.surveillance.databinding.ActivityForgotPasswordBinding
 import com.icl.surveillance.models.DbResetPasswordData
 import com.icl.surveillance.network.RetrofitCallsAuthentication
 import com.icl.surveillance.utils.FormatterClass
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 class ForgotPasswordActivity : AppCompatActivity() {
     private lateinit var binding: ActivityForgotPasswordBinding
@@ -55,45 +55,40 @@ class ForgotPasswordActivity : AppCompatActivity() {
                     idNumber = emailAddress,
                     email = emailAddress
                 )
-                CoroutineScope(Dispatchers.Main).launch {
-
+                lifecycleScope.launch {
                     val progressDialog = ProgressDialog(this@ForgotPasswordActivity)
                     progressDialog.setTitle("Please wait..")
                     progressDialog.setMessage("Authentication in progress..")
                     progressDialog.setCanceledOnTouchOutside(false)
                     progressDialog.show()
 
-                    val job = Job()
-                    CoroutineScope(Dispatchers.IO + job).launch {
-                        FormatterClass().saveSharedPref(
-                            "idNumber",
-                            emailAddress,
-                            this@ForgotPasswordActivity
-                        )
-                        val pairReturn = retrofitCallsAuthentication
-                            .getResetPassword(this@ForgotPasswordActivity, payload)
-
-                        val messageCode = pairReturn.first
-                        val messageToast = pairReturn.second
-
-                        CoroutineScope(Dispatchers.Main).launch {
-                            Toast.makeText(
-                                this@ForgotPasswordActivity, messageToast,
-                                Toast.LENGTH_SHORT
-                            ).show()
-                            if (messageCode == 200 || messageCode == 201) {
-                                val intent = Intent(
-                                    this@ForgotPasswordActivity,
-                                    ResetPasswordActivity::class.java
-                                )
-                                startActivity(intent)
-                                this@ForgotPasswordActivity.finish()
-                            }
+                    try {
+                        val (messageCode, messageToast) = withContext(Dispatchers.IO) {
+                            FormatterClass().saveSharedPref(
+                                "idNumber",
+                                emailAddress,
+                                this@ForgotPasswordActivity
+                            )
+                            retrofitCallsAuthentication
+                                .getResetPassword(this@ForgotPasswordActivity, payload)
                         }
 
-                    }.join()
-                    progressDialog.dismiss()
-
+                        Toast.makeText(
+                            this@ForgotPasswordActivity,
+                            messageToast,
+                            Toast.LENGTH_SHORT
+                        ).show()
+                        if (messageCode == 200 || messageCode == 201) {
+                            val intent = Intent(
+                                this@ForgotPasswordActivity,
+                                ResetPasswordActivity::class.java
+                            )
+                            startActivity(intent)
+                            this@ForgotPasswordActivity.finish()
+                        }
+                    } finally {
+                        progressDialog.dismiss()
+                    }
                 }
 
             }

--- a/app/src/main/java/com/icl/surveillance/auth/ResetPasswordActivity.kt
+++ b/app/src/main/java/com/icl/surveillance/auth/ResetPasswordActivity.kt
@@ -8,15 +8,15 @@ import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
+import androidx.lifecycle.lifecycleScope
 import com.icl.surveillance.R
 import com.icl.surveillance.databinding.ActivityResetPasswordBinding
 import com.icl.surveillance.models.DbSetPasswordReq
 import com.icl.surveillance.network.RetrofitCallsAuthentication
 import com.icl.surveillance.utils.FormatterClass
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 class ResetPasswordActivity : AppCompatActivity() {
     private lateinit var binding: ActivityResetPasswordBinding
@@ -75,7 +75,7 @@ class ResetPasswordActivity : AppCompatActivity() {
                     binding.confirmPasswordInputLayout.error = null
                 }
 
-                CoroutineScope(Dispatchers.Main).launch {
+                lifecycleScope.launch {
 
                     val progressDialog = ProgressDialog(this@ResetPasswordActivity)
                     progressDialog.setTitle("Please wait..")
@@ -83,32 +83,29 @@ class ResetPasswordActivity : AppCompatActivity() {
                     progressDialog.setCanceledOnTouchOutside(false)
                     progressDialog.show()
 
-                    val job = Job()
-                    CoroutineScope(Dispatchers.IO + job).launch {
-                        val idNumber =
-                            FormatterClass().getSharedPref("idNumber", this@ResetPasswordActivity)
-                        val dbSetPasswordReq = DbSetPasswordReq(code, "$idNumber", password)
-                        val pairReturn = retrofitCallsAuthentication
-                            .setPassword(this@ResetPasswordActivity, dbSetPasswordReq)
-
-                        val messageCode = pairReturn.first
-                        val messageToast = pairReturn.second
-
-                        CoroutineScope(Dispatchers.Main).launch {
-                            Toast.makeText(
-                                this@ResetPasswordActivity, messageToast,
-                                Toast.LENGTH_SHORT
-                            ).show()
-                            if (messageCode == 200 || messageCode == 201) {
-                                val intent = Intent(
-                                    this@ResetPasswordActivity,
-                                    LoginActivity::class.java
-                                )
-                                startActivity(intent)
-                            }
+                    try {
+                        val (messageCode, messageToast) = withContext(Dispatchers.IO) {
+                            val idNumber =
+                                FormatterClass().getSharedPref("idNumber", this@ResetPasswordActivity)
+                            val dbSetPasswordReq = DbSetPasswordReq(code, "$idNumber", password)
+                            retrofitCallsAuthentication
+                                .setPassword(this@ResetPasswordActivity, dbSetPasswordReq)
                         }
-                    }.join()
-                    progressDialog.dismiss()
+
+                        Toast.makeText(
+                            this@ResetPasswordActivity, messageToast,
+                            Toast.LENGTH_SHORT
+                        ).show()
+                        if (messageCode == 200 || messageCode == 201) {
+                            val intent = Intent(
+                                this@ResetPasswordActivity,
+                                LoginActivity::class.java
+                            )
+                            startActivity(intent)
+                        }
+                    } finally {
+                        progressDialog.dismiss()
+                    }
 
                 }
             }

--- a/app/src/main/java/com/icl/surveillance/fhir/MpoxSyncWorker.kt
+++ b/app/src/main/java/com/icl/surveillance/fhir/MpoxSyncWorker.kt
@@ -1,26 +1,23 @@
 package com.icl.surveillance.fhir
 
 import android.content.Context
-import androidx.work.Worker
+import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
 
 
 class MpoxSyncWorker(
     appContext: Context,
     workerParams: WorkerParameters,
-) : Worker(appContext, workerParams) {
+) : CoroutineWorker(appContext, workerParams) {
     private val repo = FhirRepository(appContext)
 
-    override fun doWork(): Result {
+    override suspend fun doWork(): Result {
         return try {
-            runBlocking {
+            withContext(Dispatchers.IO) {
                 // Step 1: Upload Patients
                 prepareListInBatches("patients", applicationContext)
-                // Wait until done (since suspending)
 
                 // Step 2: Upload Encounters
                 prepareEncountersBatches("encounters", applicationContext)
@@ -43,36 +40,26 @@ class MpoxSyncWorker(
 
     private fun prepareListInBatches(nameQuery: String, context: Context) {
         // move your code here but make it suspend-friendly
-        CoroutineScope(Dispatchers.IO).launch {
-            repo.handleDataUpload(nameQuery, context)
-        }
+        repo.handleDataUpload(nameQuery, context)
     }
 
     private fun prepareEncountersBatches(nameQuery: String, context: Context) {
         // move your code here but make it suspend-friendly
-        CoroutineScope(Dispatchers.IO).launch {
-            repo.handleDataUpload(nameQuery, context)
-        }
+        repo.handleDataUpload(nameQuery, context)
     }
 
     private fun prepareObsBatches(nameQuery: String, context: Context) {
         // move your code here but make it suspend-friendly
-        CoroutineScope(Dispatchers.IO).launch {
-            repo.handleDataUpload(nameQuery, context)
-        }
+        repo.handleDataUpload(nameQuery, context)
     }
 
     private fun prepareMeasureReportsBatches(nameQuery: String, context: Context) {
         // move your code here but make it suspend-friendly
-        CoroutineScope(Dispatchers.IO).launch {
-            repo.handleDataUpload(nameQuery, context)
-        }
+        repo.handleDataUpload(nameQuery, context)
     }
 
     private fun prepareQuestionnaireResponsesBatches(nameQuery: String, context: Context) {
         // move your code here but make it suspend-friendly
-        CoroutineScope(Dispatchers.IO).launch {
-            repo.handleDataUpload(nameQuery, context)
-        }
+        repo.handleDataUpload(nameQuery, context)
     }
 }

--- a/app/src/main/java/com/icl/surveillance/network/RetrofitCallsAuthentication.kt
+++ b/app/src/main/java/com/icl/surveillance/network/RetrofitCallsAuthentication.kt
@@ -25,7 +25,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import okhttp3.RequestBody
 import retrofit2.Response
 
@@ -401,11 +400,7 @@ class RetrofitCallsAuthentication {
         Log.d("UserPrefs", "User info saved to SharedPreferences: $userDetails")
     }
 
-    fun getResetPassword(context: Context, dbResetPasswordData: DbResetPasswordData) = runBlocking {
-        resetPassword(context, dbResetPasswordData)
-    }
-
-    private suspend fun resetPassword(
+    suspend fun getResetPassword(
         context: Context,
         dbResetPasswordData: DbResetPasswordData
     ): Pair<Int, String> {
@@ -459,11 +454,7 @@ class RetrofitCallsAuthentication {
         }
     }
 
-    fun setPassword(context: Context, dbSetPasswordReq: DbSetPasswordReq) = runBlocking {
-        setPasswordBac(context, dbSetPasswordReq)
-    }
-
-    private suspend fun setPasswordBac(
+    suspend fun setPassword(
         context: Context,
         dbSetPasswordReq: DbSetPasswordReq
     ): Pair<Int, String> {

--- a/app/src/main/java/com/icl/surveillance/ui/patients/PatientListViewModel.kt
+++ b/app/src/main/java/com/icl/surveillance/ui/patients/PatientListViewModel.kt
@@ -30,6 +30,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.withContext
 import java.time.LocalDate
 import java.time.ZoneId
 import kotlinx.coroutines.launch
@@ -313,7 +314,7 @@ class PatientListViewModel(
     }
 
     private fun sendSingleEntry(jsonParser: IParser, patientResource: Patient, context: Context) {
-        viewModelScope.launch {
+        viewModelScope.launch(Dispatchers.IO) {
             val payload = jsonParser.encodeResourceToString(patientResource)
             val apiCall = RetrofitCallsAuthentication()
 
@@ -328,7 +329,7 @@ class PatientListViewModel(
         bundle: Bundle,
         context: Context
     ) {
-        viewModelScope.launch {
+        viewModelScope.launch(Dispatchers.IO) {
             println("API Response:::: Preparing data")
             val payload = jsonParser.encodeResourceToString(bundle)
             val apiCall = RetrofitCallsAuthentication()
@@ -463,16 +464,16 @@ class PatientListViewModel(
     }
 
     fun handleCurrentCaseListing(category: String) {
-        viewModelScope.launch {
-            liveSearchedCases.value = retrieveCasesByDisease(category)
-
+        viewModelScope.launch(Dispatchers.IO) {
+            val results = retrieveCasesByDisease(category)
+            withContext(Dispatchers.Main) { liveSearchedCases.value = results }
         }
     }
 
     fun handleCurrentRumorCaseListing(category: String) {
-        viewModelScope.launch {
-            liveRumorCases.value = retrieveRumorCasesByDisease(category)
-//            patientCount.value = count()
+        viewModelScope.launch(Dispatchers.IO) {
+            val results = retrieveRumorCasesByDisease(category)
+            withContext(Dispatchers.Main) { liveRumorCases.value = results }
         }
     }
 
@@ -1246,9 +1247,13 @@ class PatientListViewModel(
         search: suspend () -> List<PatientItem>,
         count: suspend () -> Long,
     ) {
-        viewModelScope.launch {
-            liveSearchedPatients.value = search()
-            patientCount.value = count()
+        viewModelScope.launch(Dispatchers.IO) {
+            val patients = search()
+            val total = count()
+            withContext(Dispatchers.Main) {
+                liveSearchedPatients.value = patients
+                patientCount.value = total
+            }
         }
     }
 

--- a/app/src/main/java/com/icl/surveillance/viewmodels/AddClientViewModel.kt
+++ b/app/src/main/java/com/icl/surveillance/viewmodels/AddClientViewModel.kt
@@ -179,7 +179,7 @@ class AddClientViewModel(application: Application, private val state: SavedState
         context: Context,
         measureReport: MeasureReport
     ) {
-        viewModelScope.launch {
+        viewModelScope.launch(Dispatchers.IO) {
             val qh = QuestionnaireHelper()
             val formatter = FormatterClass()
             val facility = formatter.getSharedPref("facility", context)
@@ -305,7 +305,7 @@ class AddClientViewModel(application: Application, private val state: SavedState
         updatedResponse: QuestionnaireResponse,
         context: Context
     ) {
-        viewModelScope.launch {
+        viewModelScope.launch(Dispatchers.IO) {
             val questionnaireResponse = populateReportingSiteAnswers(updatedResponse, context)
 
             if (QuestionnaireResponseValidator.validateQuestionnaireResponse(

--- a/app/src/main/java/com/icl/surveillance/viewmodels/ClientDetailsViewModel.kt
+++ b/app/src/main/java/com/icl/surveillance/viewmodels/ClientDetailsViewModel.kt
@@ -58,8 +58,9 @@ class ClientDetailsViewModel(
 
     /** Emits list of [PatientDetailData]. */
     fun getPatientDetailData(category: String, parent: String?) {
-        viewModelScope.launch {
-            livePatientData.value = getPatientDetailDataModel(category, parent)
+        viewModelScope.launch(Dispatchers.IO) {
+            val patientDetails = getPatientDetailDataModel(category, parent)
+            withContext(Dispatchers.Main) { livePatientData.value = patientDetails }
         }
     }
 

--- a/app/src/main/java/com/icl/surveillance/viewmodels/EditSupervisorChecklistViewModel.kt
+++ b/app/src/main/java/com/icl/surveillance/viewmodels/EditSupervisorChecklistViewModel.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.hl7.fhir.r4.model.Enumerations
 import org.hl7.fhir.r4.model.Observation
 import org.hl7.fhir.r4.model.Patient
@@ -82,11 +83,11 @@ class EditSupervisorChecklistViewModel(
         questionnaire: String?,
         questionnaireResponseString: String
     ) {
-        viewModelScope.launch {
+        viewModelScope.launch(Dispatchers.IO) {
             questionnaireResponse.id = questionnaireId
             fhirEngine.update(questionnaireResponse)
 
-            isResourcesSaved.value = true
+            withContext(Dispatchers.Main) { isResourcesSaved.value = true }
 
             // Let's use a supervisor job to further process changes
             when (questionnaire) {

--- a/app/src/main/java/com/icl/surveillance/viewmodels/PeriodicSyncViewModel.kt
+++ b/app/src/main/java/com/icl/surveillance/viewmodels/PeriodicSyncViewModel.kt
@@ -20,6 +20,7 @@ import java.util.concurrent.TimeUnit
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import android.text.format.DateFormat
 import java.time.OffsetDateTime
@@ -33,7 +34,7 @@ class PeriodicSyncViewModel(application: Application) : AndroidViewModel(applica
     private val _pollPeriodicSyncJobStatus = MutableSharedFlow<PeriodicSyncJobStatus>(replay = 10)
 
     init {
-        viewModelScope.launch { initializePeriodicSync() }
+        viewModelScope.launch(Dispatchers.IO) { initializePeriodicSync() }
     }
 
     suspend fun initializePeriodicSync() {
@@ -53,7 +54,7 @@ class PeriodicSyncViewModel(application: Application) : AndroidViewModel(applica
     }
 
     fun collectPeriodicSyncJobStatus() {
-        viewModelScope.launch {
+        viewModelScope.launch(Dispatchers.IO) {
             _pollPeriodicSyncJobStatus.collect { periodicSyncJobStatus ->
 
                 val lastSyncStatus = getLastSyncStatus(periodicSyncJobStatus.lastSyncJobStatus)
@@ -79,7 +80,7 @@ class PeriodicSyncViewModel(application: Application) : AndroidViewModel(applica
     }
 
     fun cancelPeriodicSyncJob() {
-        viewModelScope.launch {
+        viewModelScope.launch(Dispatchers.IO) {
             Sync.cancelPeriodicSync<AppFhirSyncWorker>(
                 getApplication<FhirApplication>().applicationContext,
             )

--- a/app/src/main/java/com/icl/surveillance/viewmodels/ScreenerViewModel.kt
+++ b/app/src/main/java/com/icl/surveillance/viewmodels/ScreenerViewModel.kt
@@ -18,9 +18,9 @@ import com.icl.surveillance.utils.FormatterClass
 import com.icl.surveillance.utils.QuestionnaireHelper
 import java.util.Date
 import java.util.UUID
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.hl7.fhir.r4.model.CodeableConcept
 import org.hl7.fhir.r4.model.Coding
 import org.hl7.fhir.r4.model.Enumerations
@@ -87,22 +87,21 @@ class ScreenerViewModel(application: Application, private val state: SavedStateH
         questionnaireResponseString: String,
         appContext: Context
     ) {
-        viewModelScope.launch {
+        viewModelScope.launch(Dispatchers.IO) {
             val bundle =
                 ResourceMapper.extract(questionnaireResource, questionnaireResponse)
             val context = FhirContext.forR4()
             val questionnaire =
                 context.newJsonParser().encodeResourceToString(questionnaireResponse)
 
-            CoroutineScope(Dispatchers.IO).launch {
-                try {
-                    val title = "afp-contact-case-information"
-                    val linkReference = Reference("Patient/$patientId")
-                    val encounterId = generateUuid()
-                    val contactId = generateUuid()
+            try {
+                val title = "afp-contact-case-information"
+                val linkReference = Reference("Patient/$patientId")
+                val encounterId = generateUuid()
+                val contactId = generateUuid()
 
-                    val contact = Patient()
-                    contact.id = contactId
+                val contact = Patient()
+                contact.id = contactId
 
 
                     val identifierSystem0 = Identifier()
@@ -264,10 +263,9 @@ class ScreenerViewModel(application: Application, private val state: SavedStateH
                         println("Data Found LinkId: ${it.linkId}, Text: ${it.text}, Answer: ${it.answer}")
                     }
 
-                    CoroutineScope(Dispatchers.Main).launch { isResourcesSaved.value = true }
+                    withContext(Dispatchers.Main) { isResourcesSaved.value = true }
                 } catch (e: Exception) {
-
-                    CoroutineScope(Dispatchers.Main).launch { isResourcesSaved.value = false }
+                    withContext(Dispatchers.Main) { isResourcesSaved.value = false }
                 }
             }
         }
@@ -281,10 +279,9 @@ class ScreenerViewModel(application: Application, private val state: SavedStateH
         questionnaireResponseString: String,
         appContext: Context
     ) {
-        viewModelScope.launch {
+        viewModelScope.launch(Dispatchers.IO) {
 
-            CoroutineScope(Dispatchers.IO).launch {
-                try {
+            try {
                     val identifierSystem0 = Identifier()
                     val typeCodeableConcept0 = CodeableConcept()
                     val codingList0 = ArrayList<Coding>()
@@ -357,10 +354,10 @@ class ScreenerViewModel(application: Application, private val state: SavedStateH
                         createResource(obs, subjectReference, encounterReference, appContext)
                     }
 
-                    CoroutineScope(Dispatchers.Main).launch { isResourcesSaved.value = true }
+                    withContext(Dispatchers.Main) { isResourcesSaved.value = true }
                 } catch (e: Exception) {
                     e.printStackTrace()
-                    CoroutineScope(Dispatchers.Main).launch { isResourcesSaved.value = false }
+                    withContext(Dispatchers.Main) { isResourcesSaved.value = false }
                 }
             }
         }

--- a/app/src/main/java/com/icl/surveillance/viewmodels/SyncFragmentViewModel.kt
+++ b/app/src/main/java/com/icl/surveillance/viewmodels/SyncFragmentViewModel.kt
@@ -9,6 +9,7 @@ import androidx.lifecycle.viewModelScope
 import com.google.android.fhir.sync.CurrentSyncJobStatus
 import com.google.android.fhir.sync.Sync
 import com.icl.surveillance.fhir.AppFhirSyncWorker
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.launch
 import java.time.OffsetDateTime
@@ -32,7 +33,7 @@ class SyncFragmentViewModel(application: Application) : AndroidViewModel(applica
 
     // This function is now the single point of action to start a sync
     fun triggerOneTimeSync() {
-        viewModelScope.launch {
+        viewModelScope.launch(Dispatchers.IO) {
             // Set initial state for UI
             _syncState.value = SyncState.Running
 
@@ -56,7 +57,7 @@ class SyncFragmentViewModel(application: Application) : AndroidViewModel(applica
 
     // This function is not the issue, but it's good to have
     fun cancelOneTimeSyncWork() {
-        viewModelScope.launch { Sync.cancelOneTimeSync<AppFhirSyncWorker>(getApplication()) }
+        viewModelScope.launch(Dispatchers.IO) { Sync.cancelOneTimeSync<AppFhirSyncWorker>(getApplication()) }
     }
 
     /** Emits last sync time. */


### PR DESCRIPTION
## Summary
- shift viewmodel sync and data processing flows to use Dispatchers.IO to avoid blocking the UI thread
- update LiveData emissions to hop back to the main thread after background work
- remove ad-hoc coroutine scopes by consolidating background work inside viewModelScope for questionnaires and sync tasks

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691eb5d81c548321834526f9cc737fa9)